### PR TITLE
Rename CORE_SERVICE_URL to ROOT_REDIRECT_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN  chown nginx -Rf /etc/nginx
 ENV DNS_SERVER=8.8.8.8 \
     MBAAS_HOST_BASE=localhost  \
     MBAAS_PROTOCOL=https       \
-    CORE_SERVICE_URL=localhost \
+    ROOT_REDIRECT_URL=localhost \
     LOG_LEVEL=info
 
 USER 998

--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ To run service pull image from registry:
 
 Run downloaded image 
 
-    docker run -it -p 80:8080 \
-    -e MBAAS_HOST_BASE=yourserver.feedhenry.com \
-    -e MBAAS_PROTOCOL=https \
-    -e DNS_SERVER=8.8.8.8 \
-    -e CORE_SERVICE_URL=https://rhmap.yourdomain.net wtrocki/nginx-proxy:centos7
+    docker run -it -p 80:8080 -e MBAAS_HOST_BASE=yourserver.feedhenry.com wtrocki/nginx-proxy:centos7
 
 
 ## Environment variables
@@ -61,8 +57,8 @@ MbaaS protocol. By default https. Added for debug purposes
 DNS server that would be used to retrieve ips. 
 For internal networks you would need to specify your local DNS server.
 
+> ROOT_REDIRECT_URL `optional`
 
-> CORE_SERVICE_URL `optional`
+Full url that would be used when proxing without path (just hostname). For example: `https://yourdomain.net`
+You can redirect to any internal website that would be used as main website for nginx domain.
 
-Full url to RHMAP gui. For example: `https://rhmap.yourdomain.net`
-If you do not wish to redirect to core service please redirect to any internal website that would be used as base for this domain.

--- a/root/etc/nginx/nginx.conf.tpl
+++ b/root/etc/nginx/nginx.conf.tpl
@@ -20,7 +20,7 @@ http {
         
         ## Match root to proxy to platform gui.
         location = / {
-            return 301 ${CORE_SERVICE_URL};
+            return 301 ${ROOT_REDIRECT_URL};
         }
 
         location = /favicon.ico {


### PR DESCRIPTION
Upon initial feedback changing CORE_SERVICE_URL url to ROOT_REDIRECT_URL. This redirect would be done only for root path and it's just added to to support cases when proxy has direct internet access.