### PR TITLE
RHMAP-12508 - direct proxy to mbaas router

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN chmod 777 -Rf /var/opt/rh/rh-nginx18 && \
 
 ## Default values for required environment variables
 ENV DNS_SERVER=8.8.8.8 \
-    MBAAS_HOST_BASE=localhost  \
-    MBAAS_PROTOCOL=https       \
+    MBAAS_ROUTER_URL=localhost  \
     ROOT_REDIRECT_URL=localhost \
     LOG_LEVEL=info
 

--- a/README.md
+++ b/README.md
@@ -32,31 +32,24 @@ Proxy can be launched on any operating system that supports docker (Windows, Lin
 
 To run service pull image from registry:
 
-    docker pull wtrocki/nginx-proxy:centos7
+    docker pull wtrocki/nginx-proxy:direct
 
 Run downloaded image 
 
-    docker run -it -p 80:8080 -e MBAAS_HOST_BASE=yourserver.feedhenry.com wtrocki/nginx-proxy:centos7
+    docker run -it -p 80:8080 -e ROOT_REDIRECT_URL=http://yourserver.feedhenry.com wtrocki/nginx-proxy:centos7
 
 
 ## Environment variables
 
-> MBAAS_HOST_BASE `required`
+> ROOT_REDIRECT_URL `required`
 
-OpenShift MbaaS hostname without subdomain part. 
-If your app has route `https://appname.mbaas.net`  then `MBAAS_HOST_BASE` should be set to `mbaas.net`
-
->  MBAAS_PROTOCOL `optional`
-
-MbaaS protocol. By default https. Added for debug purposes
-
+OpenShift MbaaS router URL
+ 
 > DNS_SERVER `optional`
 
 DNS server that would be used to retrieve ips. 
 For internal networks you would need to specify your local DNS server.
-
 > ROOT_REDIRECT_URL `optional`
 
 Full url that would be used when proxing without path (just hostname). For example: `https://yourdomain.net`
 You can redirect to any internal website that would be used as main website for nginx domain.
-

--- a/README.md
+++ b/README.md
@@ -7,12 +7,7 @@ mbaas requests outside OpenShift environment.
 
 Provide mapping and proxy between public nginx proxy and
 mbaas and core components running on openshift platform.
-By default proxy would use single hostname for every mbaas application 
-and I would map first element of the path into subdomain internally.
-
-> For example request to https://feedhenryplatform.net/yourapp/endpoint?test=3 will proxy to https://yourapp.feedhenryplatform.net/endpoint?test=3
-
-Proxy root path (https://feedhenryplatform.net) would redirect to platform GUI
+By default proxy would use single hostname for every mbaas application.
 
 ## Runnning
 

--- a/openshift/rhmap-nginx-proxy.json
+++ b/openshift/rhmap-nginx-proxy.json
@@ -14,7 +14,7 @@
             "description": "MbaaS Router URL",
             "required": true
         },
-                {
+        {
             "name": "ROOT_REDIRECT_URL",
             "value": "http://localhost/invalid",
             "description": "Full url to RHMAP platform GUI. For example https://rhmap.yourdomain.com",

--- a/openshift/rhmap-nginx-proxy.json
+++ b/openshift/rhmap-nginx-proxy.json
@@ -73,7 +73,7 @@
                         "containers": [
                             {
                                 "name": "nginx-proxy",
-                                "image": "wtrocki/nginx-proxy",
+                                "image": "wtrocki/nginx-proxy:direct",
                                 "ports": [
                                     {
                                         "containerPort": 8080,

--- a/openshift/rhmap-nginx-proxy.json
+++ b/openshift/rhmap-nginx-proxy.json
@@ -9,12 +9,12 @@
     },
     "parameters": [
         {
-            "name": "MBAAS_HOST_BASE",
+            "name": "MBAAS_ROUTER_URL",
             "value": "",
-            "description": "base hostname (without subdomain) for mbaas",
+            "description": "MbaaS Router URL",
             "required": true
         },
-        {
+                {
             "name": "ROOT_REDIRECT_URL",
             "value": "http://localhost/invalid",
             "description": "Full url to RHMAP platform GUI. For example https://rhmap.yourdomain.com",
@@ -82,8 +82,8 @@
                                 ],
                                 "env": [
                                     {
-                                        "name": "MBAAS_HOST_BASE",
-                                        "value": "${MBAAS_HOST_BASE}"
+                                        "name": "MBAAS_ROUTER_URL",
+                                        "value": "${MBAAS_ROUTER_URL}"
                                     },
                                     {
                                         "name": "ROOT_REDIRECT_URL",

--- a/root/etc/nginx/nginx.conf.tpl
+++ b/root/etc/nginx/nginx.conf.tpl
@@ -1,8 +1,8 @@
 daemon off;
 
 http {
-    include    /etc/nginx/proxy.conf;
-    include    /etc/nginx/mime.types;
+    include /etc/nginx/proxy.conf;
+    include /etc/nginx/mime.types;
 
     server {
 	    client_body_temp_path /tmp/nginx_client_temp 1 2;
@@ -10,22 +10,14 @@ http {
         resolver ${DNS_SERVER};
         access_log /dev/stdout;
 
-        ## App init rewrite
+        ## Expose platform app init api
         location = /box/srv/1.1/app/init {
            proxy_pass ${ROOT_REDIRECT_URL}/$request_uri;
         }
-
-        ## Match every first element of the path and proxy to subdomain 
-        ## https://test.net/value/test will proxy to https://value.test.net/test
-        location ~* ^/([^/]+)(.*) {
-            proxy_pass ${MBAAS_PROTOCOL}://$1.${MBAAS_HOST_BASE}/$2$is_args$args;
-            proxy_redirect ${MBAAS_PROTOCOL}://$1.${MBAAS_HOST_BASE} /$1;
-            proxy_cookie_path / /$1;
-        }
-
-        ## Match root to proxy to platform gui.
-        location = / {
-            return 301 ${ROOT_REDIRECT_URL};
+        
+        ## Redirect every request to mbaas router proxy
+        location / {
+            proxy_pass ${MBAAS_ROUTER_URL}/$request_uri;
         }
 
         location = /favicon.ico {

--- a/root/usr/bin/nginx18
+++ b/root/usr/bin/nginx18
@@ -4,15 +4,13 @@ set -e -o pipefail
 echo "Updating configuration"
 echo "      
       DNS SERVER ${DNS_SERVER}
-      MBASS HOST ${MBAAS_HOST_BASE}
-      MBAAS PROTOCOL ${MBAAS_PROTOCOL}
+      MBAAS_ROUTER_URL ${MBAAS_ROUTER_URL}
       ROOT_REDIRECT_URL ${ROOT_REDIRECT_URL}
       LOG_LEVEL ${LOG_LEVEL}
 " 
 
 envsubst '${DNS_SERVER}
-          ${MBAAS_HOST_BASE}
-          ${MBAAS_PROTOCOL}
+          ${MBAAS_ROUTER_URL}
           ${ROOT_REDIRECT_URL}
           ${LOG_LEVEL}' < "/etc/nginx/nginx.conf.tpl" > "/etc/nginx/nginx.conf"
 


### PR DESCRIPTION
Remove rewrite and direct proxy to mbaas router while still rewriting app init call.

Pushed to docker with `direct` label

We can use this as frontend for environment proxy @PhilipGough

@philbrookes - you can use this as base for cert investigation.