### PR TITLE
Redirect environment path

### DIFF
--- a/openshift/rhmap-nginx-proxy.json
+++ b/openshift/rhmap-nginx-proxy.json
@@ -73,7 +73,7 @@
                         "containers": [
                             {
                                 "name": "nginx-proxy",
-                                "image": "wtrocki/nginx-proxy:direct",
+                                "image": "wtrocki/nginx-proxy:redirect-env",
                                 "ports": [
                                     {
                                         "containerPort": 8080,

--- a/root/etc/nginx/nginx.conf.tpl
+++ b/root/etc/nginx/nginx.conf.tpl
@@ -14,12 +14,15 @@ http {
         location = /box/srv/1.1/app/init {
            proxy_pass ${ROOT_REDIRECT_URL}/$request_uri;
         }
-        
-        ## Redirect every request to mbaas router proxy
-        location / {
-            proxy_pass ${MBAAS_ROUTER_URL}/$request_uri;
-        }
 
+        ## Redirect environment part of the hostname
+        ## Example test.com/envid/appid/someurl
+        location ~* ^/([^/]+)/([^/]+)(.*) {
+            proxy_pass https://$1.${MBAAS_ROUTER_URL}/$2$3$is_args$args;
+            proxy_redirect https://$1.${MBAAS_ROUTER_URL} /$1/$2;
+            proxy_cookie_path / /$1/$2;
+        }
+        
         location = /favicon.ico {
             log_not_found off;
         }


### PR DESCRIPTION
## Running it

```docker run -it -p 80:8080 -e=MBAAS_HOST_BASE=1mos.feedhenry.net -e=MBAAS_PROTOCOL=https -e=LOG_LEVEL=debug -e=DNS_SERVER=10.11.5.19  -e=ROOT_REDIRECT_URL=https://rhmap.mos3.feedhenry.net wtrocki/nginx-proxy:redirect-env```

ping @PhilipGough